### PR TITLE
Update Windows installer

### DIFF
--- a/build/include.nsh
+++ b/build/include.nsh
@@ -13,17 +13,18 @@
 !macro customInstall
     ${If} ${FileExists} `${SWAP_DIR}\*.*`
         ; swapperd is a directory
-        Goto run_installer
+        ; if an installer.exe already exists we delete and overwrite it
+        IfFileExists "${SWAP_DIR}\bin\installer.exe" 0 run_installer
+        Delete "${SWAP_DIR}\bin\installer.exe"
     ${ElseIf} ${FileExists} `${SWAP_DIR}`
         ; swapperd is a file
         Goto end_of_test
     ${Else}
         ; swapperd folder doesn't exist
         CreateDirectory "${SWAP_DIR}\bin"
-        CopyFiles /SILENT "$INSTDIR\bin\*.*" "${SWAP_DIR}\bin"
     ${EndIf}
     run_installer:
-    IfFileExists "${SWAP_DIR}\bin\installer.exe" 0 end_of_test
+    CopyFiles /SILENT "$INSTDIR\bin\installer.exe" "${SWAP_DIR}\bin"
     ExecShellWait "" "${SWAP_DIR}\bin\installer.exe" SW_HIDE
     end_of_test:
 !macroend

--- a/build/include.nsh
+++ b/build/include.nsh
@@ -21,7 +21,6 @@
         ; swapperd folder doesn't exist
         CreateDirectory "${SWAP_DIR}\bin"
         CopyFiles /SILENT "$INSTDIR\bin\*.*" "${SWAP_DIR}\bin"
-        CopyFiles /SILENT "$INSTDIR\config.json" "${SWAP_DIR}"
     ${EndIf}
     run_installer:
     IfFileExists "${SWAP_DIR}\bin\installer.exe" 0 end_of_test

--- a/packaging/afterPackHook.ts
+++ b/packaging/afterPackHook.ts
@@ -12,7 +12,6 @@ import { checkFileExists } from "../src/common/functions";
 import { getLatestAssets, GitAsset } from "../src/common/gitReleases";
 
 const WINDOWS_SWAPPERD_FILE = "swapper_windows_amd64.zip";
-const CONFIG_FILE = "config.json";
 
 interface AfterPackContext {
     outDir: string;
@@ -97,12 +96,6 @@ export default async function (context: AfterPackContext) {
                     case WINDOWS_SWAPPERD_FILE:
                         file = await checkFile(asset);
                         await extractZip(file, context.appOutDir);
-                        break;
-                    case CONFIG_FILE:
-                        file = await checkFile(asset);
-                        const configPath = path.resolve(path.join(context.appOutDir, CONFIG_FILE));
-                        fs.copyFileSync(file, configPath);
-                        console.log(`Copied ${file} to ${configPath}`);
                         break;
                     default:
                 }


### PR DESCRIPTION
Do to the changes that were made to the Windows installer and updater in SwapperD, we no longer need to package the `config.json` file. Additionally we only need to copy the `installer.exe`.