### PR TITLE
Use orb jobs for merging branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ version: 2.1
 orbs:
     core: ren/circleci-orbs@dev:first
 
-_defaults: &defaults
+executors:
+  default_exec:
     docker:
       - image: circleci/node:8.15
     working_directory: ~/swapperd-desktop
@@ -49,7 +50,7 @@ commands:
 
 jobs:
   release:
-    <<: *defaults
+    executor: default_exec
     steps:
       - checkout
       - install_deps
@@ -57,26 +58,8 @@ jobs:
           name: Deploying to Releases
           command: |-
             GH_TOKEN="${GITHUB_TOKEN}" yarn run release
-  merge_nightly:
-    <<: *defaults
-    steps:
-      - core/merge:
-          from: master
-          into: nightly
-  merge_beta:
-    <<: *defaults
-    steps:
-      - core/merge:
-          from: nightly
-          into: beta
-  merge_stable:
-    <<: *defaults
-    steps:
-      - core/merge:
-          from: beta
-          into: stable
   build:
-    <<: *defaults
+    executor: default_exec
     steps:
       - checkout
       - install_deps
@@ -107,7 +90,8 @@ workflows:
               only:
                 - master
     jobs:
-      - merge_nightly
+      - core/merge_nightly:
+          executor: default_exec
   monthly:
     triggers:
       - schedule:
@@ -117,8 +101,10 @@ workflows:
               only:
                 - master
     jobs:
-      - merge_stable
-      - merge_beta:
+      - core/merge_stable:
+          executor: default_exec
+      - core/merge_beta:
+          executor: default_exec
           # Only run merge_beta after merge_stable is run
           requires:
-            - merge_stable
+            - core/merge_stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,6 @@ commands:
           name: Restore node_modules
           keys:
             - v1-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
@@ -51,8 +49,7 @@ jobs:
       - install_deps
       - run:
           name: Deploying to Releases
-          command: |-
-            GH_TOKEN="${GITHUB_TOKEN}" yarn run release
+          command: GH_TOKEN="${GITHUB_TOKEN}" yarn run release
   build:
     executor: default
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,7 @@ commands:
   install_deps:
     description: "Install dependencies"
     steps:
-      - run:
-          name: Install Wine
-          command: |-
-            sudo dpkg --add-architecture i386
-            sudo apt-get update
-            sudo apt-get install --no-install-recommends --assume-yes wine wine32
+      - core/install_wine
       # Download and cache dependencies
       - restore_cache:
           name: Restore node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
     core: ren/circleci-orbs@dev:first
 
 executors:
-  default_exec:
+  default:
     docker:
       - image: circleci/node:8.15
     working_directory: ~/swapperd-desktop
@@ -50,7 +50,7 @@ commands:
 
 jobs:
   release:
-    executor: default_exec
+    executor: default
     steps:
       - checkout
       - install_deps
@@ -59,7 +59,7 @@ jobs:
           command: |-
             GH_TOKEN="${GITHUB_TOKEN}" yarn run release
   build:
-    executor: default_exec
+    executor: default
     steps:
       - checkout
       - install_deps
@@ -91,7 +91,7 @@ workflows:
                 - master
     jobs:
       - core/merge_nightly:
-          executor: default_exec
+          executor: default
   monthly:
     triggers:
       - schedule:
@@ -102,9 +102,9 @@ workflows:
                 - master
     jobs:
       - core/merge_stable:
-          executor: default_exec
+          executor: default
       - core/merge_beta:
-          executor: default_exec
+          executor: default
           # Only run merge_beta after merge_stable is run
           requires:
             - core/merge_stable


### PR DESCRIPTION
This PR uses the merge jobs of nightly, beta, stable inside of the core orb. This reduces the size of the `config.yml` file.