### PR TITLE
Fix up packaging scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ yarn-error.log*
 
 # prebuild scripts
 /packaging/*.js
-/src/common/*.js

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "release": "sh ./patch_version.sh ./package.json; yarn run build:all -p always; git checkout HEAD -- ./package.json"
   },
   "dependencies": {
-    "@types/rc-progress": "^2.2.1",
     "auto-launch": "^5.0.5",
     "axios": "^0.18.0",
     "bcryptjs": "^2.4.3",
@@ -94,6 +93,7 @@
     "@types/menubar": "^5.1.6",
     "@types/node": "^10.12.21",
     "@types/node-notifier": "^0.0.28",
+    "@types/rc-progress": "^2.2.1",
     "@types/react": "^16.8.1",
     "@types/react-dom": "^16.0.11",
     "@types/sqlite3": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -45,14 +45,16 @@
   "scripts": {
     "lint": "tslint --project ./ -t stylish",
     "start": "electron-webpack dev",
-    "build": "electron-webpack && electron-builder",
+    "build": "electron-webpack && yarn run package",
     "build:all": "yarn run build --x64 -wml",
     "build:win": "yarn run build --x64 -w",
     "build:mac": "yarn run build -m",
     "build:linux": "yarn run build -l",
     "build:dir": "yarn run build --dir -c.compression=store -c.mac.identity=null",
     "postinstall": "patch-package && electron-builder install-app-deps",
-    "prebuild": "tsc packaging/afterPackHook.ts --lib es2015 --skipLibCheck",
+    "package": "electron-builder",
+    "prepackage": "tsc packaging/afterPackHook.ts --lib es2015 --skipLibCheck --resolveJsonModule",
+    "postpackage": "rm -rf ./src/common/*.js",
     "test": "echo 'No tests to run'",
     "release": "sh ./patch_version.sh ./package.json; yarn run build:all -p always; git checkout HEAD -- ./package.json"
   },


### PR DESCRIPTION
Currently, the `prebuild` step is run before the `electron-webpack` step but it is really only needed for the `electron-builder` step. This occasionally causes build issues since imports will match both `*.ts` and `*.js` files. We rename the `electron-builder` step to `package`, and use `pre` and `post` hooks to compile the `afterPackHook.ts` file. We also clean up the javascript files after the `package` step completes.

Additionally, this PR also moves some typing dependencies into `devDependencies`.